### PR TITLE
[glib2] Add missing libstdc++-devel buildrequires. JB#54767

### DIFF
--- a/rpm/glib2.spec
+++ b/rpm/glib2.spec
@@ -24,6 +24,8 @@ BuildRequires: pkgconfig(libelf)
 BuildRequires: pkgconfig(libffi)
 BuildRequires: pkgconfig(libpcre)
 BuildRequires: pkgconfig(zlib)
+# for G_HAVE_ISO_VARARGS (and unused tests)
+BuildRequires: libstdc++-devel
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 


### PR DESCRIPTION
libstdc++-devel is needed a build time for glib2 to check if the C++
compiler supports ISO_VARARGS.